### PR TITLE
Split quantization logic

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,9 @@
+ python -m python_coreml_stable_diffusion.torch2quantized_coreml_create_calibration_data --convert-unet --xl-version --model-version '/home/shynggys/WorkingDirectory/3rd_party_models/DMD2/DMD2/dmd2-diffusers' --bundle-resources-for-swift-cli --attention-implementation SPLIT_EINSUM -o calibration_dir --generate-calibration-data --test
+ 
+ 
+ 
+  python -m python_coreml_stable_diffusion.torch2quantized_coreml_unet --convert-unet --xl-version --model-version '/home/shynggys/WorkingDirectory/3rd_party_models/DMD2/DMD2/dmd2-diffusers' --bundle-resources-for-swift-cli --attention-implementation SPLIT_EINSUM -o calibration_dir --generate-calibration-data --test
+  
+  
+  with open('prompts.txt', 'r', encoding='utf-8') as f:
+    CALIBRATION_DATA = [line.strip() for line in f.readlines()]

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_create_calibration_data.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_create_calibration_data.py
@@ -17,10 +17,10 @@ def main(args):
     os.makedirs(args.o, exist_ok=True)
 
     pipe = torch2coreml.get_pipeline(args)
-    if torch.backends.mps.is_available():
-        pipe.to(device="mps", dtype=torch.float32)
-    elif torch.cuda.is_available():
+    if torch.cuda.is_available():
         pipe.to(device="cuda", dtype=torch.float32)
+    elif torch.backends.mps.is_available():
+        pipe.to(device="mps", dtype=torch.float32)
     else:
         pipe.to(device="cpu", dtype=torch.float32)
 

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_create_calibration_data.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_create_calibration_data.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Apple Inc. All Rights Reserved.
+#
+"""Generate calibration data for UNet activation quantization."""
+
+import gc
+import os
+import torch
+
+from python_coreml_stable_diffusion import torch2coreml
+from python_coreml_stable_diffusion import torch2quantized_coreml_prepare as prepare
+
+
+def main(args):
+    os.makedirs(args.o, exist_ok=True)
+
+    pipe = torch2coreml.get_pipeline(args)
+    if torch.backends.mps.is_available():
+        pipe.to(device="mps", dtype=torch.float32)
+    elif torch.cuda.is_available():
+        pipe.to(device="cuda", dtype=torch.float32)
+    else:
+        pipe.to(device="cpu", dtype=torch.float32)
+
+    calib_dir = os.path.join(
+        args.o, f"calibration_data_{args.model_version.replace('/', '_')}"
+    )
+    prepare.generate_calibration_data(pipe, args, calib_dir)
+
+    del pipe
+    gc.collect()
+
+
+if __name__ == "__main__":
+    parser = prepare.parser_spec()
+    args = parser.parse_args()
+    args.generate_calibration_data = True
+    main(args)

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
@@ -51,26 +51,8 @@ def _log_device(name, obj):
 
 torch.set_grad_enabled(False)
 
-
-CALIBRATION_DATA = [
-    "image of a transparent tall glass with ice, fruits and mint, photograph, commercial, food, warm background, beautiful image, detailed",
-    "picture of dimly lit living room, minimalist furniture, vaulted ceiling, huge room, floor to ceiling window with an ocean view, nighttime, 3D render, high quality, detailed",
-    "modern office building, 8 stories tall, glass and steel, 3D render style, wide angle view, very detailed, sharp photographic image, in an office park, bright sunny day, clear blue skies, trees and landscaping",
-    "cute small cat sitting in a movie theater eating popcorn, watching a movie, cozy indoor lighting, detailed, digital painting, character design",
-    "a highly detailed matte painting of a man on a hill watching a rocket launch in the distance by studio ghibli, volumetric lighting, octane render, 4K resolution, hyperrealism, highly detailed, insanely detailed, cinematic lighting, depth of field",
-    "an undersea world with several of fish, rocks, detailed, realistic, photograph, amazing, beautiful, high resolution",
-    "large ocean wave hitting a beach at sunset, photograph, detailed",
-    "pocket watch on a table, close up. macro, sharp, high gloss, brass, gears, sharp, detailed",
-    "pocket watch in the style of pablo picasso, painting",
-    "majestic royal tall ship on a calm sea, realistic painting, cloudy blue sky, in the style of edward hopper",
-    "german castle on a mountain, blue sky, realistic, photograph, dramatic, wide angle view",
-    "artificial intelligence, AI, concept art, blue line sketch",
-    "a humanoid robot, concept art, 3D render, high quality, detailed",
-    "donut with sprinkles and a cup of coffee on a wood table, detailed, photograph",
-    "orchard at sunset, beautiful, photograph, great composition, detailed, realistic, HDR",
-    "image of a map of a country, tattered, old, styled, illustration, for a video game style",
-    "blue and green woven fibers, nano fiber material, detailed, concept art, micro photography",
-]
+with open('prompts.txt', 'r', encoding='utf-8') as f:
+    CALIBRATION_DATA = [line.strip() for line in f.readlines()]
 
 
 def register_input_log_hook(unet, inputs):

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
@@ -302,10 +302,15 @@ def convert_quantized_unet(pipe, args):
     else:
         unet_cls = unet_mod.UNet2DConditionModel
 
+    # Move pipeline UNet to CPU before collecting weights to avoid mixed
+    # device tensors in the reference model.
+    pipe.unet.to("cpu")
+
     reference_unet = unet_cls(
         support_controlnet=args.unet_support_controlnet, **pipe.unet.config
     ).eval()
     reference_unet.load_state_dict(pipe.unet.state_dict())
+    reference_unet.to("cpu")
 
     if hasattr(pipe, "text_encoder") and pipe.text_encoder is not None:
         text_token_sequence_length = pipe.text_encoder.config.max_position_embeddings

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
@@ -338,14 +338,9 @@ def convert_quantized_unet(pipe, args):
     config = quantize_cumulative_config(set(), set())
     logger.info("Quantizing UNet model")
 
-    # Quantization must run on CPU. After quantization, move the resulting model
-    # to the preferred runtime device (CUDA > MPS > CPU).
+    # Quantization must run on CPU. Keeping the resulting model on the same
+    # device avoids mixed-device errors when tracing.
     quant_device = "cpu"
-    run_device = (
-        "mps"
-        if torch.backends.mps.is_available()
-        else "cuda" if torch.cuda.is_available() else "cpu"
-    )
 
     reference_unet.to(quant_device)
     _log_device("Reference UNet", reference_unet)
@@ -354,7 +349,6 @@ def convert_quantized_unet(pipe, args):
     # reference_unet and calibration data are no longer needed
     del reference_unet, dataloader
     gc.collect()
-    quant_unet.to(run_device)
     _log_device("Quantized UNet", quant_unet)
 
     # Prepare sample input shapes

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Apple Inc. All Rights Reserved.
+#
+"""Quantize Stable Diffusion UNet and export to Core ML."""
+
+import gc
+import os
+import torch
+
+from python_coreml_stable_diffusion import torch2coreml
+from python_coreml_stable_diffusion import torch2quantized_coreml_prepare as prepare
+
+
+def main(args):
+    os.makedirs(args.o, exist_ok=True)
+
+    pipe = torch2coreml.get_pipeline(args)
+    if torch.backends.mps.is_available():
+        pipe.to(device="mps", dtype=torch.float32)
+    elif torch.cuda.is_available():
+        pipe.to(device="cuda", dtype=torch.float32)
+    else:
+        pipe.to(device="cpu", dtype=torch.float32)
+
+    prepare.convert_quantized_unet(pipe, args)
+
+    del pipe
+    gc.collect()
+
+
+if __name__ == "__main__":
+    parser = prepare.parser_spec()
+    args = parser.parse_args()
+    args.convert_unet = True
+    main(args)

--- a/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
@@ -17,10 +17,10 @@ def main(args):
     os.makedirs(args.o, exist_ok=True)
 
     pipe = torch2coreml.get_pipeline(args)
-    if torch.backends.mps.is_available():
-        pipe.to(device="mps", dtype=torch.float32)
-    elif torch.cuda.is_available():
+    if torch.cuda.is_available():
         pipe.to(device="cuda", dtype=torch.float32)
+    elif torch.backends.mps.is_available():
+        pipe.to(device="mps", dtype=torch.float32)
     else:
         pipe.to(device="cpu", dtype=torch.float32)
 


### PR DESCRIPTION
## Summary
- split `torch2quantized_coreml.py` into a reusable module `torch2quantized_coreml_prepare.py`
- create `torch2quantized_coreml_create_calibration_data.py` for generating calibration data
- create `torch2quantized_coreml_unet.py` for quantising the UNet
- ensure pipeline objects are deleted before quantisation to keep memory low

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'model_version')*

------
https://chatgpt.com/codex/tasks/task_e_686049d6a3a8832e948f5adf80e30979