### PR TITLE
Enable chunked quantized UNet conversion

### DIFF
--- a/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_unet.py
@@ -5,29 +5,15 @@
 #
 """Quantize Stable Diffusion UNet and export to Core ML."""
 
-import gc
 import os
-import torch
 
-from python_coreml_stable_diffusion import torch2coreml
 from python_coreml_stable_diffusion import torch2quantized_coreml_prepare as prepare
 
 
 def main(args):
     os.makedirs(args.o, exist_ok=True)
 
-    pipe = torch2coreml.get_pipeline(args)
-    if torch.cuda.is_available():
-        pipe.to(device="cuda", dtype=torch.float32)
-    elif torch.backends.mps.is_available():
-        pipe.to(device="mps", dtype=torch.float32)
-    else:
-        pipe.to(device="cpu", dtype=torch.float32)
-
-    prepare.convert_quantized_unet(pipe, args)
-
-    del pipe
-    gc.collect()
+    prepare.main(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support splitting quantized UNet in `torch2quantized_coreml_prepare`
- expose conversion of ControlNet, refiner UNet and MMDiT for quantization
- call full prepare flow from `torch2quantized_coreml_unet.py`
- avoid empty chunk when bisecting quantized models

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'model_version')*
- `python -m py_compile python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py python_coreml_stable_diffusion/torch2quantized_coreml_unet.py`

------
https://chatgpt.com/codex/tasks/task_e_68740a815edc832e88eb18e45b9a8ea0