### PR TITLE
Improve weight split search

### DIFF
--- a/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
@@ -267,10 +267,6 @@ def _prepare_calibration(pipe, args, calib_dir):
 def convert_quantized_unet(pipe, args):
     """Quantize `pipe.unet` and convert it to Core ML."""
     out_path = torch2coreml._get_out_path(args, "unet")
-<<<<<<< HEAD
-
-=======
->>>>>>> parent of 3f13c32 (Merge pull request #17 from china-mashina/codex/explain-chunk_mlprogram.py-legacy-split-method)
     if os.path.exists(out_path):
         logger.info(f"`unet` already exists at {out_path}, skipping conversion.")
         return


### PR DESCRIPTION
## Summary
- rewrite `_get_op_idx_split_location` to use a forward BFS from each constant and compute active weight sizes via prefix sums
- remove merge conflict markers in `torch2quantized_coreml_prepare.py`

## Testing
- `python -m python_coreml_stable_diffusion.sdxl2coreml --help` *(fails: Cannot load model due to blocked network access)*
- `pytest -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f844e9c74832eb2496a5fa9eae732