### PR TITLE
Add layerwise sensitivity analysis

### DIFF
--- a/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
+++ b/python_coreml_stable_diffusion/torch2quantized_coreml_prepare.py
@@ -10,6 +10,7 @@ import gc
 import logging
 import os
 import pickle
+import json
 import operator
 from collections import OrderedDict
 from copy import deepcopy
@@ -17,6 +18,7 @@ from copy import deepcopy
 import coremltools as ct
 import numpy as np
 import torch
+from tqdm import tqdm
 from coremltools.optimize.torch.quantization import (
     LinearQuantizer,
     LinearQuantizerConfig,
@@ -174,6 +176,87 @@ def unet_data_loader(data_dir, device="cpu", calibration_nsamples=None):
     return dataloader
 
 
+def quantize_module_config(module_name):
+    """Return config that quantizes only the specified module."""
+
+    config = LinearQuantizerConfig(
+        global_config=ModuleLinearQuantizerConfig(
+            milestones=[0, 1000, 1000, 0],
+            weight_dtype=torch.float32,
+            activation_dtype=torch.float32,
+        ),
+        module_name_configs={
+            module_name: ModuleLinearQuantizerConfig(
+                quantization_scheme="symmetric",
+                milestones=[0, 1000, 1000, 0],
+            )
+        },
+        module_type_configs={
+            torch.cat: None,
+            torch.nn.GroupNorm: None,
+            torch.nn.SiLU: None,
+            torch.nn.functional.gelu: None,
+            operator.add: None,
+        },
+    )
+    return config
+
+
+def get_quantizable_modules(unet):
+    """Return list of leaf modules that can be quantized."""
+
+    quantizable_modules = []
+    for name, module in unet.named_modules():
+        if len(list(module.children())) > 0:
+            continue
+        if isinstance(module, torch.nn.Conv2d):
+            quantizable_modules.append(("conv", name))
+        if isinstance(module, Einsum):
+            quantizable_modules.append(("einsum", name))
+    return quantizable_modules
+
+
+def recipe_overrides_for_inference_speed(conv_layers, skipped_conv):
+    """Force quantization for known compute hotspots."""
+
+    for layer in conv_layers:
+        # Quantize upsample stack convolutions
+        if "upsamplers" in layer and layer in skipped_conv:
+            logger.info(f"Removing {layer} from skip list")
+            skipped_conv.remove(layer)
+        # Quantize conv1 in up path resnets
+        if (
+            "up_blocks" in layer
+            and "resnets" in layer
+            and "conv1" in layer
+            and layer in skipped_conv
+        ):
+            logger.info(f"Removing {layer} from skip list")
+            skipped_conv.remove(layer)
+
+
+def recipe_overrides_for_quality(conv_layers, einsum_layers, skipped_conv, skipped_einsum):
+    """Skip layers that are sensitive to quantization artifacts."""
+
+    for layer in conv_layers:
+        # to_out projections from attention blocks
+        if "to_out" in layer:
+            skipped_conv.add(layer)
+        # First and last UNet convolutions
+        if layer in {"conv_in", "conv_out"}:
+            skipped_conv.add(layer)
+        # High resolution up path last resblocks
+        if "up_blocks.3" in layer:
+            skipped_conv.add(layer)
+        # Mid-block attention convolutions
+        if "mid_block.attentions" in layer:
+            skipped_conv.add(layer)
+
+    for layer in einsum_layers:
+        if "mid_block.attentions" in layer:
+            skipped_einsum.add(layer)
+
+
 def quantize_cumulative_config(skip_conv_layers, skip_einsum_layers):
     """Return LinearQuantizerConfig for W8A8 quantization."""
 
@@ -286,6 +369,88 @@ def _prepare_calibration(pipe, args, calib_dir):
     return dataloader
 
 
+def register_input_preprocessing_hook(pipe):
+    """Register hook to adapt pipeline inputs for the quantized UNet."""
+
+    def hook(_, args, kwargs):
+        sample = args[0]
+        timestep = args[1]
+        encoder_hidden_states = kwargs["encoder_hidden_states"]
+        time_ids = kwargs.get("time_ids")
+        text_embeds = kwargs.get("text_embeds")
+        if "added_cond_kwargs" in kwargs:
+            added = kwargs["added_cond_kwargs"]
+            if isinstance(added, dict):
+                time_ids = time_ids or added.get("time_ids")
+                text_embeds = text_embeds or added.get("text_embeds")
+        modified = _to_coreml_unet_inputs(
+            sample, timestep, encoder_hidden_states, time_ids, text_embeds
+        )
+        return (modified, {})
+
+    return pipe.unet.register_forward_pre_hook(hook, with_kwargs=True)
+
+
+def prepare_pipe(pipe, unet):
+    """Create a new pipeline with ``unet`` as the noise predictor."""
+
+    new_pipe = deepcopy(pipe)
+    unet.to(new_pipe.unet.device)
+    new_pipe.unet = unet
+    pre_hook_handle = register_input_preprocessing_hook(new_pipe)
+    return new_pipe, pre_hook_handle
+
+
+def run_pipe(pipe, prompts, negative_prompts, seed):
+    gen = torch.manual_seed(seed)
+    kwargs = dict(prompt=prompts, output_type="latent", generator=gen)
+    if negative_prompts is not None:
+        kwargs["negative_prompt"] = negative_prompts
+        kwargs["guidance_scale"] = 0
+    return np.array([latent.cpu().numpy() for latent in pipe(**kwargs).images])
+
+
+def layerwise_sensitivity(pipe, args):
+    """Compute layer-wise PSNR by quantizing one layer at a time."""
+
+    calib_dir = os.path.join(args.o, "calibration_data")
+    dataloader = _prepare_calibration(pipe, args, calib_dir)
+
+    prompts = CALIBRATION_DATA if not getattr(args, "test", False) else CALIBRATION_DATA[:1]
+    negative_prompts = (
+        NEGATIVE_CALIBRATION_DATA
+        if not getattr(args, "test", False)
+        else NEGATIVE_CALIBRATION_DATA[:1]
+    )
+
+    logger.info("Generating reference outputs")
+    ref_out = run_pipe(pipe, prompts, negative_prompts, args.seed)
+
+    quantizable_modules = get_quantizable_modules(pipe.unet)
+    results = {"conv": {}, "einsum": {}, "model_version": args.model_version}
+
+    for module_type, module_name in tqdm(quantizable_modules):
+        logger.info(f"Quantizing UNet layer: {module_name}")
+        config = quantize_module_config(module_name)
+        quantized_unet = quantize(deepcopy(pipe.unet), config, dataloader)
+        q_pipe, _ = prepare_pipe(pipe, quantized_unet)
+        test_out = run_pipe(q_pipe, prompts, negative_prompts, args.seed)
+        psnr = [float(f"{torch2coreml.compute_psnr(r, t):.1f}") for r, t in zip(ref_out, test_out)]
+        avg_psnr = sum(psnr) / len(psnr)
+        logger.info(f"AVG PSNR: {avg_psnr}")
+        results[module_type][module_name] = avg_psnr
+        del quantized_unet, q_pipe
+        gc.collect()
+
+    recipe_json_path = os.path.join(
+        args.o, f"{args.model_version.replace('/', '_')}_quantization_recipe.json"
+    )
+    with open(recipe_json_path, "w") as f:
+        json.dump(results, f, indent=2)
+
+    logger.info(f"Layer-wise sensitivity results saved to {recipe_json_path}")
+
+
 def convert_quantized_unet(pipe, args):
     """Quantize ``pipe.unet`` and convert it to Core ML."""
     out_path = torch2coreml._get_out_path(args, "unet")
@@ -350,8 +515,37 @@ def convert_quantized_unet(pipe, args):
     del pipe
     gc.collect()
 
+    # Quantization recipe from layerwise sensitivity
+    recipe_json_path = os.path.join(
+        args.o, f"{args.model_version.replace('/', '_')}_quantization_recipe.json"
+    )
+    if os.path.exists(recipe_json_path):
+        with open(recipe_json_path, "r") as f:
+            results = json.load(f)
+        skipped_conv = {
+            layer for layer, psnr in results["conv"].items() if psnr < args.conv_psnr
+        }
+        skipped_einsum = set()
+        for layer, psnr in results["einsum"].items():
+            if "attn" in layer or "attention" in layer:
+                thresh = args.attn_psnr
+            else:
+                thresh = args.mlp_psnr
+            if psnr < thresh:
+                skipped_einsum.add(layer)
+        conv_layers = list(results["conv"].keys())
+        einsum_layers = list(results["einsum"].keys())
+        recipe_overrides_for_inference_speed(conv_layers, skipped_conv)
+        recipe_overrides_for_quality(
+            conv_layers, einsum_layers, skipped_conv, skipped_einsum
+        )
+    else:
+        logger.warning("Quantization recipe not found. Quantizing all layers.")
+        skipped_conv = set()
+        skipped_einsum = set()
+
     # Quantize UNet weights and activations (W8A8 by default)
-    config = quantize_cumulative_config(set(), set())
+    config = quantize_cumulative_config(skipped_conv, skipped_einsum)
     logger.info("Quantizing UNet model")
 
     # Quantization must run on CPU. Keeping the resulting model on the same
@@ -493,7 +687,9 @@ def main(args):
 
     # Load diffusers pipeline as in torch2coreml
     pipe = torch2coreml.get_pipeline(args)
-    if torch.cuda.is_available():
+    if args.layerwise_sensitivity:
+        pipe.to(device="cpu", dtype=torch.float32)
+    elif torch.cuda.is_available():
         pipe.to(device="cuda", dtype=torch.float32)
     elif torch.backends.mps.is_available():
         pipe.to(device="mps", dtype=torch.float32)
@@ -511,7 +707,10 @@ def main(args):
     unet_mod.ATTENTION_IMPLEMENTATION_IN_EFFECT = unet_mod.AttentionImplementations[
         args.attention_implementation
     ]
-    
+
+    if args.layerwise_sensitivity:
+        layerwise_sensitivity(pipe, args)
+
     if args.convert_unet:
         convert_quantized_unet(pipe, args)
         del pipe
@@ -541,6 +740,29 @@ def parser_spec():
         "--test",
         action="store_true",
         help="Run calibration data generation on a single prompt",
+    )
+    parser.add_argument(
+        "--layerwise-sensitivity",
+        action="store_true",
+        help="Compute compression sensitivity per-layer, by quantizing one layer at a time",
+    )
+    parser.add_argument(
+        "--conv-psnr",
+        type=float,
+        default=42.0,
+        help="PSNR threshold for convolution layers",
+    )
+    parser.add_argument(
+        "--attn-psnr",
+        type=float,
+        default=35.0,
+        help="PSNR threshold for attention linear layers",
+    )
+    parser.add_argument(
+        "--mlp-psnr",
+        type=float,
+        default=36.0,
+        help="PSNR threshold for MLP linear layers",
     )
     return parser
 


### PR DESCRIPTION
## Summary
- apply SDXL quality and speed overrides when preparing cumulative quantization config
- expose PSNR thresholds for conv, attention, and MLP layers
- skip non-tensor ops like GroupNorm, SiLU, gelu, cat and add during per-layer and cumulative quantization

## Testing
- `pytest` *(fails: RuntimeError: Failed to import diffusers ... libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688f7960ccd4832ea55304e6ddf11f13